### PR TITLE
Chore/add sonarcloud

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,0 +1,20 @@
+name: Analysis
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-orange.svg)](https://sonarcloud.io/summary/new_code?id=oliverosborne9_rpi_api)
+
 # mechanic
 
 Device module (Python package and Docker container) with HTTP API for reading from electronic scales and controlling servo motors. Designed for Raspberry Pi, running a Debian-based distribution.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-orange.svg)](https://sonarcloud.io/summary/new_code?id=oliverosborne9_rpi_api)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=oliverosborne9_rpi_api&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=oliverosborne9_rpi_api) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=oliverosborne9_rpi_api&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=oliverosborne9_rpi_api)
 
 # mechanic
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=oliverosborne9_rpi_api
+sonar.organization=oliverosborne9
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=rpi_api
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Integrate Sonarcloud 
- GitHub Action running on each pull request or commit to main branch
- Highlights code smells, and security hotspots, for review
- Added badge to README showing sonarcloud is used in this project

### Added Future Capabilities
- Add more checks into the "Analysis" GitHub action, such as `pre-commit` linting or running of tests
- Setup quality gates on Sonarcloud, required criteria before allowing a merge into the main branch